### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.OutputFilter
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
 #  UnitTesting:
 #    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0
@@ -96,9 +97,21 @@ jobs:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.6
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.7
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.8
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
 #        ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=edaa-org.github.io%2FpyEDAA.OutputFilter&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fedaa-org.github.io%2FpyEDAA.OutputFilter%2Findex.html)](https://edaa-org.github.io/pyEDAA.OutputFilter/)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
 [![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.OutputFilter/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.OutputFilter/actions/workflows/Pipeline.yml)
+[![Codacy - Quality](https://img.shields.io/codacy/grade/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.OutputFilter)
 
 <!--
 [![Sourcecode License](https://img.shields.io/pypi/l/pyEDAA.OutputFilter?longCache=true&style=flat-square&logo=Apache&label=code)](LICENSE.md)
@@ -16,8 +17,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyEDAA.OutputFilter?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
 
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyEDAA.OutputFilter?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pyEDAA.OutputFilter)
-[![Codacy - Quality](https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.OutputFilter)
-[![Codacy - Coverage](https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.OutputFilter)
+[![Codacy - Coverage](https://img.shields.io/codacy/coverage/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.OutputFilter)
 [![Codecov - Branch Coverage](https://img.shields.io/codecov/c/github/edaa-org/pyEDAA.OutputFilter?longCache=true&style=flat-square&logo=Codecov)](https://codecov.io/gh/edaa-org/pyEDAA.OutputFilter)
 
 [![Dependent repos (via libraries.io)](https://img.shields.io/librariesio/dependent-repos/pypi/pyEDAA.OutputFilter?longCache=true&style=flat-square&logo=GitHub)](https://GitHub.com/edaa-org/pyEDAA.OutputFilter/network/dependents)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,16 +16,16 @@
 .. only:: html
 
    |  |SHIELD:svg:OutputFilter-github| |SHIELD:svg:OutputFilter-ghp-doc| |SHIELD:svg:OutputFilter-gitter|
-   |  |SHIELD:svg:OutputFilter-gha-test|
+   |  |SHIELD:svg:OutputFilter-gha-test| |SHIELD:svg:OutputFilter-codacy-quality|
 
-.. Disabled shields: |SHIELD:svg:OutputFilter-src-license| |SHIELD:svg:OutputFilter-doc-license| |SHIELD:svg:OutputFilter-pypi-tag| |SHIELD:svg:OutputFilter-pypi-status| |SHIELD:svg:OutputFilter-pypi-python| |SHIELD:svg:OutputFilter-lib-status| |SHIELD:svg:OutputFilter-codacy-quality| |SHIELD:svg:OutputFilter-codacy-coverage| |SHIELD:svg:OutputFilter-codecov-coverage| |SHIELD:svg:OutputFilter-lib-dep| |SHIELD:svg:OutputFilter-req-status| |SHIELD:svg:OutputFilter-lib-rank|
+.. Disabled shields: |SHIELD:svg:OutputFilter-src-license| |SHIELD:svg:OutputFilter-doc-license| |SHIELD:svg:OutputFilter-pypi-tag| |SHIELD:svg:OutputFilter-pypi-status| |SHIELD:svg:OutputFilter-pypi-python| |SHIELD:svg:OutputFilter-lib-status| |SHIELD:svg:OutputFilter-codacy-coverage| |SHIELD:svg:OutputFilter-codecov-coverage| |SHIELD:svg:OutputFilter-lib-dep| |SHIELD:svg:OutputFilter-req-status| |SHIELD:svg:OutputFilter-lib-rank|
 
 .. only:: latex
 
    |SHIELD:png:OutputFilter-github| |SHIELD:png:OutputFilter-ghp-doc| |SHIELD:png:OutputFilter-gitter|
-   |SHIELD:png:OutputFilter-gha-test|
+   |SHIELD:png:OutputFilter-gha-test| |SHIELD:png:OutputFilter-codacy-quality|
 
-.. Disabled shields: |SHIELD:png:OutputFilter-src-license| |SHIELD:png:OutputFilter-doc-license| |SHIELD:png:OutputFilter-pypi-tag| |SHIELD:png:OutputFilter-pypi-status| |SHIELD:png:OutputFilter-pypi-python| |SHIELD:png:OutputFilter-lib-status| |SHIELD:png:OutputFilter-codacy-quality| |SHIELD:png:OutputFilter-codacy-coverage| |SHIELD:png:OutputFilter-codecov-coverage| |SHIELD:png:OutputFilter-lib-dep| |SHIELD:png:OutputFilter-req-status| |SHIELD:png:OutputFilter-lib-rank|
+.. Disabled shields: |SHIELD:png:OutputFilter-src-license| |SHIELD:png:OutputFilter-doc-license| |SHIELD:png:OutputFilter-pypi-tag| |SHIELD:png:OutputFilter-pypi-status| |SHIELD:png:OutputFilter-pypi-python| |SHIELD:png:OutputFilter-lib-status| |SHIELD:png:OutputFilter-codacy-coverage| |SHIELD:png:OutputFilter-codecov-coverage| |SHIELD:png:OutputFilter-lib-dep| |SHIELD:png:OutputFilter-req-status| |SHIELD:png:OutputFilter-lib-rank|
 
 The pyEDAA.OutputFilter Documentation
 #####################################

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -74,21 +74,21 @@
    :target: https://GitHub.com/edaa-org/pyEDAA.OutputFilter/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
-.. |SHIELD:svg:OutputFilter-codacy-quality| image:: https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:OutputFilter-codacy-quality| image:: https://img.shields.io/codacy/grade/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.OutputFilter
-.. |SHIELD:png:OutputFilter-codacy-quality| image:: https://raster.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:OutputFilter-codacy-quality| image:: https://raster.shields.io/codacy/grade/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.OutputFilter
 
 .. # Codacy - coverage
-.. |SHIELD:svg:OutputFilter-codacy-coverage| image:: https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:OutputFilter-codacy-coverage| image:: https://img.shields.io/codacy/coverage/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.OutputFilter
-.. |SHIELD:png:OutputFilter-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:OutputFilter-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/4918480c41594ffbb62f8ff98433b800?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.OutputFilter


### PR DESCRIPTION
# Changes

* ci/Params: override python_version_list, since 3.6 was deprecated in pyTooling/Actions.
* doc: update codacy shields.