### PR TITLE
v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ```python
 from pathlib import Path
-from pyEDAA.OutputFilter.Xilinx.Synthesis import Processor
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import Processor
 
 logfile = Path("tests/data/Stopwatch/toplevel.vds")
 processor = Processor(logfile)

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -102,7 +102,7 @@ the mandatory dependencies too.
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `typing-extensions <https://GitHub.com/python/typing_extensions>`__ | ≥4.14       | `PSF-2.0 <https://github.com/python/typing_extensions/blob/main/LICENSE>`__            | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
-| `lxml <https://GitHub.com/lxml/lxml>`__                             | ≥5.4        | `BSD 3-Clause <https://GitHub.com/lxml/lxml/blob/master/LICENSE.txt>`__                | *Not yet evaluated.* |
+| `lxml <https://GitHub.com/lxml/lxml>`__                             | ≥6.0        | `BSD 3-Clause <https://GitHub.com/lxml/lxml/blob/master/LICENSE.txt>`__                | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 
 

--- a/pyEDAA/OutputFilter/CLI/Vivado.py
+++ b/pyEDAA/OutputFilter/CLI/Vivado.py
@@ -121,7 +121,7 @@ class VivadoHandlers(metaclass=ExtendedType, mixin=True):
 			self.WriteNormal(influxString)
 
 		if args.summary:
-			synthesizeDesign = processor[SynthesizeDesign]
+			synthesizeDesign : SynthesizeDesign = processor[SynthesizeDesign]
 			self.WriteNormal("Summary:")
 			self.WriteNormal(f"  Tool version:        {processor.Preamble.ToolVersion}")
 			self.WriteNormal(f"  Started at:          {processor.Preamble.StartDatetime}")
@@ -137,7 +137,7 @@ class VivadoHandlers(metaclass=ExtendedType, mixin=True):
 			if synthesizeDesign.HasLatches:
 				for cellName in ("LD", ):
 					try:
-						self.WriteNormal(f"    {cellName}: {processor.Cells[cellName]}")
+						self.WriteNormal(f"    {cellName}: {synthesizeDesign.Cells[cellName]}")
 					except KeyError:
 						pass
 				for latch in synthesizeDesign.Latches:
@@ -147,14 +147,14 @@ class VivadoHandlers(metaclass=ExtendedType, mixin=True):
 				for bbox in synthesizeDesign.Blackboxes:
 					self.WriteNormal(f"    {bbox}")
 
-			self.WriteNormal(f"VHDL report statements ({len(processor.VHDLReportMessages)}):")
-			for message in processor.VHDLReportMessages:
+			self.WriteNormal(f"VHDL report statements ({len(synthesizeDesign.VHDLReportMessages)}):")
+			for message in synthesizeDesign.VHDLReportMessages:
 				self.WriteNormal(f"  {message}")
-			self.WriteNormal(f"VHDL assert statements ({len(processor.VHDLAssertMessages)}):")
-			for message in processor.VHDLAssertMessages:
+			self.WriteNormal(f"VHDL assert statements ({len(synthesizeDesign.VHDLAssertMessages)}):")
+			for message in synthesizeDesign.VHDLAssertMessages:
 				self.WriteNormal(f"  {message}")
 
-			self.WriteNormal(f"Cells: {len(processor.Cells)}")
+			self.WriteNormal(f"Cells: {len(synthesizeDesign.Cells)}")
 			for cell, count in synthesizeDesign.Cells.items():
 				self.WriteNormal(f"  {cell}: {count}")
 

--- a/pyEDAA/OutputFilter/CLI/Vivado.py
+++ b/pyEDAA/OutputFilter/CLI/Vivado.py
@@ -160,39 +160,40 @@ class VivadoHandlers(metaclass=ExtendedType, mixin=True):
 
 	def ColoredOutput(self, lines: Iterable[Line]) -> None:
 		for i, line in enumerate(lines, start=1):
+			message = str(line).replace("{", "{{").replace("}", "}}")
 			if isinstance(line, ProcessorException):
-				print(f"{i:4}: {{RED}}EXCEPTION:{{NOCOLOR}} {line}".format(**self.Foreground))
+				print(f"{i:4}: {{RED}}EXCEPTION:{{NOCOLOR}} {message}".format(**self.Foreground))
 			elif line.Kind is LineKind.Normal:
 				print(f"{i:4}: {line.Message}")
 			elif LineKind.Message in line.Kind:
 				if line.Kind is LineKind.InfoMessage:
-					print(f"{i:4}: {{BLUE}}{line}{{NOCOLOR}}".format(**self.Foreground))
+					print(f"{i:4}: {{BLUE}}{message}{{NOCOLOR}}".format(**self.Foreground))
 				elif line.Kind is LineKind.WarningMessage:
-					print(f"{i:4}: {{YELLOW}}{line}{{NOCOLOR}}".format(**self.Foreground))
+					print(f"{i:4}: {{YELLOW}}{message}{{NOCOLOR}}".format(**self.Foreground))
 				elif line.Kind is LineKind.CriticalWarningMessage:
-					print(f"{i:4}: {{MAGENTA}}{line}{{NOCOLOR}}".format(**self.Foreground))
+					print(f"{i:4}: {{MAGENTA}}{message}{{NOCOLOR}}".format(**self.Foreground))
 				elif line.Kind is LineKind.ErrorMessage:
-					print(f"{i:4}: {{RED}}{line}{{NOCOLOR}}".format(**self.Foreground))
+					print(f"{i:4}: {{RED}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.TclCommand in line.Kind:
-				print(f"{i:4}: {{CYAN}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{CYAN}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif (LineKind.Start in line.Kind) or (LineKind.End in line.Kind):
-				print(f"{i:4}: {{DARK_CYAN}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{DARK_CYAN}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif line.Kind is LineKind.ParagraphHeadline:
-				print(f"{i:4}: {{DARK_YELLOW}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{DARK_YELLOW}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.Table in line.Kind:
-				print(f"{i:4}: {{WHITE}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{WHITE}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.Delimiter in line.Kind:
-				print(f"{i:4}: {{GRAY}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{GRAY}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.Verbose in line.Kind:
-				print(f"{i:4}: {{DARK_GRAY}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{DARK_GRAY}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.Success in line.Kind:
-				print(f"{i:4}: {{GREEN}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{GREEN}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif line.Kind is LineKind.Empty:
 				print(f"{i:4}:")
 			elif line.Kind is LineKind.ProcessorError:
-				print(f"{i:4}: {{RED}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{RED}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif line.Kind is LineKind.Unprocessed:
-				print(f"{i:4}: {{DARK_RED}}{line}{{NOCOLOR}}".format(**self.Foreground))
+				print(f"{i:4}: {{DARK_RED}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			else:
 				print(f"{i:4}: Unknown LineKind '{line._kind}' for line {line._lineNumber}.")
 				print(line)

--- a/pyEDAA/OutputFilter/CLI/Vivado.py
+++ b/pyEDAA/OutputFilter/CLI/Vivado.py
@@ -179,7 +179,10 @@ class VivadoHandlers(metaclass=ExtendedType, mixin=True):
 			elif LineKind.TclCommand in line.Kind:
 				print(f"{i:4}: {{CYAN}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif (LineKind.Start in line.Kind) or (LineKind.End in line.Kind):
-				print(f"{i:4}: {{DARK_CYAN}}{message}{{NOCOLOR}}".format(**self.Foreground))
+				if LineKind.Phase in line.Kind:
+					print(f"{i:4}: {{YELLOW}}{message}{{NOCOLOR}}".format(**self.Foreground))
+				else:
+					print(f"{i:4}: {{DARK_CYAN}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif line.Kind is LineKind.ParagraphHeadline:
 				print(f"{i:4}: {{DARK_YELLOW}}{message}{{NOCOLOR}}".format(**self.Foreground))
 			elif LineKind.Table in line.Kind:

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -29,7 +29,7 @@
 # ==================================================================================================================== #
 #
 """Basic classes for outputs from AMD/Xilinx Vivado."""
-from typing               import ClassVar, Generator, Union, List, Type, Dict, Iterator
+from typing import ClassVar, Generator, Union, List, Type, Dict, Iterator, Any
 
 from pyTooling.Decorators import export, readonly
 

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -220,7 +220,12 @@ class SynthesizeDesign(Command):
 
 						lastLine = yield line
 						return lastLine
-
+				elif line.StartsWith("Finished RTL Optimization Phase"):
+					line._kind = LineKind.PhaseEnd
+					line._previousLine._kind = LineKind.PhaseEnd | LineKind.PhaseDelimiter
+				elif line.StartsWith("----"):
+					if LineKind.Phase in line._previousLine._kind:
+						line._kind = LineKind.PhaseEnd | LineKind.PhaseDelimiter
 				elif not isinstance(line, VivadoMessage):
 					pass
 					# line._kind = LineKind.Unprocessed

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -241,6 +241,9 @@ class SynthesizeDesign(Command):
 						line = yield section.send(line)
 						break
 
+				if isinstance(line, VivadoMessage):
+					self._AddMessage(line)
+
 				line = yield section.send(line)
 
 			line = yield section.send(line)

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -197,6 +197,7 @@ class SynthesizeDesign(Command):
 					for parser in activeParsers:  # type: Section
 						if line.StartsWith(parser._START):
 							line = next(section := parser.Generator(line))
+							line._previousLine._kind = LineKind.SectionStart | LineKind.SectionDelimiter
 							break
 					else:
 						raise Exception(f"Unknown section: {line}")
@@ -205,6 +206,7 @@ class SynthesizeDesign(Command):
 					if line.StartsWith(rtlElaboration._START):
 						parser = rtlElaboration
 						line = next(section := parser.Generator(line))
+						line._previousLine._kind = LineKind.SectionStart | LineKind.SectionDelimiter
 						break
 				elif line.StartsWith(self._TCL_COMMAND):
 					if line[len(self._TCL_COMMAND) + 1:].startswith("completed successfully"):

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -236,8 +236,10 @@ class SynthesizeDesign(Command):
 
 			while True:
 				if line.StartsWith("Finished"):
-					line = yield section.send(line)
-					break
+					l = line[9:]
+					if not (l.startswith("Flattening") or l.startswith("Final")):
+						line = yield section.send(line)
+						break
 
 				line = yield section.send(line)
 

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -1,0 +1,231 @@
+# ==================================================================================================================== #
+#               _____ ____    _        _      ___        _               _   _____ _ _ _                               #
+#   _ __  _   _| ____|  _ \  / \      / \    / _ \ _   _| |_ _ __  _   _| |_|  ___(_) | |_ ___ _ __                    #
+#  | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | | | | __| '_ \| | | | __| |_  | | | __/ _ \ '__|                   #
+#  | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |_| | |_| |_) | |_| | |_|  _| | | | ||  __/ |                      #
+#  | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \__,_|\__| .__/ \__,_|\__|_|   |_|_|\__\___|_|                      #
+#  |_|    |___/                                             |_|                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2025-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Basic classes for outputs from AMD/Xilinx Vivado."""
+from typing               import ClassVar, Generator, Union, List, Type, Dict, Iterator
+
+from pyTooling.Decorators import export, readonly
+
+from pyEDAA.OutputFilter.Xilinx import VivadoTclCommand
+from pyEDAA.OutputFilter.Xilinx.Exception import ProcessorException
+from pyEDAA.OutputFilter.Xilinx.Common    import Line, LineKind, VivadoMessage
+from pyEDAA.OutputFilter.Xilinx.Common2   import Parser
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import Section, RTLElaboration, HandlingCustomAttributes1, \
+	WritingSynthesisReport, ConstraintValidation, LoadingPart, ApplySetProperty, RTLComponentStatistics, \
+	PartResourceSummary, CrossBoundaryAndAreaOptimization, ApplyingXDCTimingConstraints, TimingOptimization, \
+	TechnologyMapping, IOInsertion, FlatteningBeforeIOInsertion, FinalNetlistCleanup, RenamingGeneratedInstances, \
+	RebuildingUserHierarchy, RenamingGeneratedPorts, HandlingCustomAttributes2, RenamingGeneratedNets
+
+
+@export
+class NotPresentException(ProcessorException):
+	pass
+
+
+@export
+class SectionNotPresentException(NotPresentException):
+	pass
+
+
+@export
+class Command(Parser):
+	# _TCL_COMMAND: ClassVar[str]
+	pass
+
+
+
+
+# Parsers = Union[*PARSERS]
+
+
+
+@export
+class SynthesizeDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "synth_design"
+	_PARSERS:     ClassVar[List[Type[Section]]] = (
+		RTLElaboration,
+		HandlingCustomAttributes1,
+		ConstraintValidation,
+		LoadingPart,
+		ApplySetProperty,
+		RTLComponentStatistics,
+		PartResourceSummary,
+		CrossBoundaryAndAreaOptimization,
+		ApplyingXDCTimingConstraints,
+		TimingOptimization,
+		TechnologyMapping,
+		IOInsertion,
+		FlatteningBeforeIOInsertion,
+		FinalNetlistCleanup,
+		RenamingGeneratedInstances,
+		RebuildingUserHierarchy,
+		RenamingGeneratedPorts,
+		HandlingCustomAttributes2,
+		RenamingGeneratedNets,
+		WritingSynthesisReport,
+	)
+
+	_sections:  Dict[Type[Section], Section]
+
+	def __init__(self, processor: "Processor") -> None:
+		super().__init__(processor)
+
+		self._sections =  {p: p(self) for p in self._PARSERS}
+
+	@readonly
+	def HasLatches(self) -> bool:
+		if (8 in self._messagesByID) and (327 in self._messagesByID[8]):
+			return True
+
+		return "LD" in self._sections[WritingSynthesisReport]._cells
+
+	@readonly
+	def Latches(self) -> Iterator[VivadoMessage]:
+		try:
+			yield from iter(self._messagesByID[8][327])
+		except KeyError:
+			yield from ()
+
+	@readonly
+	def HasBlackboxes(self) -> bool:
+		return len(self._sections[WritingSynthesisReport]._blackboxes) > 0
+
+	@readonly
+	def Blackboxes(self) -> Dict[str, int]:
+		return self._sections[WritingSynthesisReport]._blackboxes
+
+	@readonly
+	def Cells(self) -> Dict[str, int]:
+		return self._sections[WritingSynthesisReport]._cells
+
+	def __getitem__(self, item: Type[Parser]) -> Union[_PARSERS]:
+		try:
+			return self._sections[item]
+		except KeyError as ex:
+			raise SectionNotPresentException(F"Section '{item._NAME}' not present in '{self._parent.logfile}'.") from ex
+
+	def SectionDetector(self, line: Line) -> Generator[Union[Line, ProcessorException], Line, None]:
+		# parser:        Section      = firstValue(self._sections)
+		activeParsers: List[Parser] = list(self._sections.values())
+
+		rtlElaboration = self._sections[RTLElaboration]
+		# constraintValidation = self._sections[ConstraintValidation]
+
+		if not (isinstance(line, VivadoTclCommand) and line._command == self._TCL_COMMAND):
+			raise ProcessorException()
+
+		line = yield line
+		if line == "Starting synth_design":
+			line._kind = LineKind.Verbose
+		else:
+			raise ProcessorException()
+
+		line = yield line
+
+		while True:
+			while True:
+				if line.StartsWith("Start "):
+					for parser in activeParsers:  # type: Section
+						if line.StartsWith(parser._START):
+							line = next(section := parser.Generator(line))
+							break
+					else:
+						raise Exception(f"Unknown section: {line}")
+					break
+				elif line.StartsWith("Starting "):
+					if line.StartsWith(rtlElaboration._START):
+						parser = rtlElaboration
+						line = next(section := parser.Generator(line))
+						break
+				elif line.StartsWith(self._TCL_COMMAND):
+					if line[len(self._TCL_COMMAND) + 1:].startswith("completed successfully"):
+						line._kind |= LineKind.Success
+
+						line = yield line
+						if line.StartsWith(self._TCL_COMMAND + ":"):
+							line._kind |= LineKind.Last
+						else:
+							pass
+
+						lastLine = yield line
+						return lastLine
+
+				elif not isinstance(line, VivadoMessage):
+					pass
+					# line._kind = LineKind.Unprocessed
+
+				line = yield line
+
+			line = yield line
+
+			while True:
+				if line.StartsWith("Finished"):
+					line = yield section.send(line)
+					break
+
+				line = yield section.send(line)
+
+			line = yield section.send(line)
+
+			activeParsers.remove(parser)
+
+
+@export
+class LinkDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "link_design"
+
+
+@export
+class OptimizeDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "opt_design"
+
+
+@export
+class PlaceDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "place_design"
+
+
+@export
+class PhysicalOptimizationDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "phys_opt_design"
+
+
+@export
+class PhysicalOptimizationDesign(Command):
+	_TCL_COMMAND: ClassVar[str] = "route_design"
+
+
+@export
+class WriteBitstream(Command):
+	_TCL_COMMAND: ClassVar[str] = "write_bitstream"
+
+# report_drc
+# report_methodology
+# report_power

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -33,15 +33,19 @@ from typing               import ClassVar, Generator, Union, List, Type, Dict, I
 
 from pyTooling.Decorators import export, readonly
 
-from pyEDAA.OutputFilter.Xilinx import VivadoTclCommand
+from pyEDAA.OutputFilter.Xilinx           import VivadoTclCommand
 from pyEDAA.OutputFilter.Xilinx.Exception import ProcessorException
-from pyEDAA.OutputFilter.Xilinx.Common    import Line, LineKind, VivadoMessage
+from pyEDAA.OutputFilter.Xilinx.Common    import Line, LineKind, VivadoMessage, VHDLReportMessage
 from pyEDAA.OutputFilter.Xilinx.Common2   import Parser
-from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import Section, RTLElaboration, HandlingCustomAttributes1, \
-	ConstraintValidation, LoadingPart, ApplySetProperty, RTLComponentStatistics, \
-	PartResourceSummary, CrossBoundaryAndAreaOptimization, ROM_RAM_DSP_SR_Retiming1, ApplyingXDCTimingConstraints, TimingOptimization, \
-	ROM_RAM_DSP_SR_Retiming2, TechnologyMapping, IOInsertion, FlatteningBeforeIOInsertion, FinalNetlistCleanup, RenamingGeneratedInstances, \
-	RebuildingUserHierarchy, RenamingGeneratedPorts, HandlingCustomAttributes2, RenamingGeneratedNets, ROM_RAM_DSP_SR_Retiming3, WritingSynthesisReport
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import Section, RTLElaboration, HandlingCustomAttributes
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import ConstraintValidation, LoadingPart, ApplySetProperty
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import RTLComponentStatistics, PartResourceSummary
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import CrossBoundaryAndAreaOptimization, ROM_RAM_DSP_SR_Retiming
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import ApplyingXDCTimingConstraints, TimingOptimization
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import TechnologyMapping, IOInsertion, FlatteningBeforeIOInsertion
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import FinalNetlistCleanup, RenamingGeneratedInstances
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import RebuildingUserHierarchy, RenamingGeneratedPorts
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import RenamingGeneratedNets, WritingSynthesisReport
 
 
 @export
@@ -55,15 +59,34 @@ class SectionNotPresentException(NotPresentException):
 
 
 @export
-class Command(Parser):
-	# _TCL_COMMAND: ClassVar[str]
+class HandlingCustomAttributes1(HandlingCustomAttributes):
 	pass
 
 
+@export
+class HandlingCustomAttributes2(HandlingCustomAttributes):
+	pass
 
 
-# Parsers = Union[*PARSERS]
+@export
+class ROM_RAM_DSP_SR_Retiming1(ROM_RAM_DSP_SR_Retiming):
+	pass
 
+
+@export
+class ROM_RAM_DSP_SR_Retiming2(ROM_RAM_DSP_SR_Retiming):
+	pass
+
+
+@export
+class ROM_RAM_DSP_SR_Retiming3(ROM_RAM_DSP_SR_Retiming):
+	pass
+
+
+@export
+class Command(Parser):
+	# _TCL_COMMAND: ClassVar[str]
+	pass
 
 
 @export
@@ -127,6 +150,22 @@ class SynthesizeDesign(Command):
 	@readonly
 	def Cells(self) -> Dict[str, int]:
 		return self._sections[WritingSynthesisReport]._cells
+
+	@readonly
+	def VHDLReportMessages(self) -> List[VHDLReportMessage]:
+		if 8 in self._messagesByID:
+			if 6031 in (synthMessages := self._messagesByID[8]):
+				return [message for message in synthMessages[6031]]
+
+		return []
+
+	@readonly
+	def VHDLAssertMessages(self) -> List[VHDLReportMessage]:
+		if 8 in self._messagesByID:
+			if 63 in (synthMessages := self._messagesByID[8]):
+				return [message for message in synthMessages[63]]
+
+		return []
 
 	def __getitem__(self, item: Type[Parser]) -> Union[_PARSERS]:
 		try:

--- a/pyEDAA/OutputFilter/Xilinx/Commands.py
+++ b/pyEDAA/OutputFilter/Xilinx/Commands.py
@@ -38,10 +38,10 @@ from pyEDAA.OutputFilter.Xilinx.Exception import ProcessorException
 from pyEDAA.OutputFilter.Xilinx.Common    import Line, LineKind, VivadoMessage
 from pyEDAA.OutputFilter.Xilinx.Common2   import Parser
 from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import Section, RTLElaboration, HandlingCustomAttributes1, \
-	WritingSynthesisReport, ConstraintValidation, LoadingPart, ApplySetProperty, RTLComponentStatistics, \
-	PartResourceSummary, CrossBoundaryAndAreaOptimization, ApplyingXDCTimingConstraints, TimingOptimization, \
-	TechnologyMapping, IOInsertion, FlatteningBeforeIOInsertion, FinalNetlistCleanup, RenamingGeneratedInstances, \
-	RebuildingUserHierarchy, RenamingGeneratedPorts, HandlingCustomAttributes2, RenamingGeneratedNets
+	ConstraintValidation, LoadingPart, ApplySetProperty, RTLComponentStatistics, \
+	PartResourceSummary, CrossBoundaryAndAreaOptimization, ROM_RAM_DSP_SR_Retiming1, ApplyingXDCTimingConstraints, TimingOptimization, \
+	ROM_RAM_DSP_SR_Retiming2, TechnologyMapping, IOInsertion, FlatteningBeforeIOInsertion, FinalNetlistCleanup, RenamingGeneratedInstances, \
+	RebuildingUserHierarchy, RenamingGeneratedPorts, HandlingCustomAttributes2, RenamingGeneratedNets, ROM_RAM_DSP_SR_Retiming3, WritingSynthesisReport
 
 
 @export
@@ -78,8 +78,10 @@ class SynthesizeDesign(Command):
 		RTLComponentStatistics,
 		PartResourceSummary,
 		CrossBoundaryAndAreaOptimization,
+		ROM_RAM_DSP_SR_Retiming1,
 		ApplyingXDCTimingConstraints,
 		TimingOptimization,
+		ROM_RAM_DSP_SR_Retiming2,
 		TechnologyMapping,
 		IOInsertion,
 		FlatteningBeforeIOInsertion,
@@ -89,6 +91,7 @@ class SynthesizeDesign(Command):
 		RenamingGeneratedPorts,
 		HandlingCustomAttributes2,
 		RenamingGeneratedNets,
+		ROM_RAM_DSP_SR_Retiming3,
 		WritingSynthesisReport,
 	)
 

--- a/pyEDAA/OutputFilter/Xilinx/Common.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common.py
@@ -1,0 +1,398 @@
+# ==================================================================================================================== #
+#               _____ ____    _        _      ___        _               _   _____ _ _ _                               #
+#   _ __  _   _| ____|  _ \  / \      / \    / _ \ _   _| |_ _ __  _   _| |_|  ___(_) | |_ ___ _ __                    #
+#  | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | | | | __| '_ \| | | | __| |_  | | | __/ _ \ '__|                   #
+#  | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |_| | |_| |_) | |_| | |_|  _| | | | ||  __/ |                      #
+#  | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \__,_|\__| .__/ \__,_|\__|_|   |_|_|\__\___|_|                      #
+#  |_|    |___/                                             |_|                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2025-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Basic classes for outputs from AMD/Xilinx Vivado."""
+from enum    import Flag
+from pathlib import Path
+from re      import Pattern, compile as re_compile
+from typing import Optional as Nullable, Self, ClassVar, Tuple, Union, Any
+
+from pyTooling.Decorators  import export, readonly
+from pyTooling.MetaClasses import ExtendedType
+
+
+@export
+class LineKind(Flag):
+	Unprocessed =                0
+	ProcessorError =         2** 0
+	Empty =                  2** 1
+	Delimiter =              2** 2
+
+	Success =                2** 3
+	Failed =                 2** 4
+
+	Verbose =                2**10
+	Normal =                 2**11
+	Info =                   2**12
+	Warning =                2**13
+	CriticalWarning =        2**14
+	Error =                  2**15
+	Fatal =                  2**16
+
+	Start =                  2**20
+	End =                    2**21
+	Header =                 2**22
+	Content =                2**23
+	Footer =                 2**24
+
+	Last =                   2**29
+
+	Message =                2**30
+	InfoMessage =            Message | Info
+	WarningMessage =         Message | Warning
+	CriticalWarningMessage = Message | CriticalWarning
+	ErrorMessage =           Message | Error
+
+	Section =                2**31
+	SectionDelimiter =       Section | Delimiter
+	SectionStart =           Section | Start
+	SectionEnd =             Section | End
+
+	SubSection =             2**32
+	SubSectionDelimiter =    SubSection | Delimiter
+	SubSectionStart =        SubSection | Start
+	SubSectionEnd =          SubSection | End
+
+	Paragraph =              2**33
+	ParagraphHeadline =      Paragraph | Header
+
+	Table =                  2**34
+	TableFrame =             Table | Delimiter
+	TableHeader =            Table | Header
+	TableRow =               Table | Content
+	TableFooter =            Table | Footer
+
+	TclCommand =             2 ** 35
+	GenericTclCommand =      TclCommand | 2**0
+	VivadoTclCommand =       TclCommand | 2**1
+
+
+@export
+class Line(metaclass=ExtendedType, slots=True):
+	"""
+	This class represents any line in a log file.
+	"""
+	_lineNumber:    int
+	_kind:          LineKind
+	_message:       str
+
+	def __init__(self, lineNumber: int, kind: LineKind, message: str) -> None:
+		self._lineNumber = lineNumber
+		self._kind = kind
+		self._message = message
+
+	@readonly
+	def LineNumber(self) -> int:
+		return self._lineNumber
+
+	@readonly
+	def Kind(self) -> LineKind:
+		return self._kind
+
+	@readonly
+	def Message(self) -> str:
+		return self._message
+
+	def Partition(self, separator: str) -> Tuple[str, str, str]:
+		return self._message.partition(separator)
+
+	def StartsWith(self, prefix: Union[str, Tuple[str, ...]]):
+		return self._message.startswith(prefix)
+
+	def __getitem__(self, item: slice) -> str:
+		return self._message[item]
+
+	def __eq__(self, other: Any):
+		return self._message == other
+
+	def __ne__(self, other: Any):
+		return self._message != other
+
+	def __str__(self) -> str:
+		return self._message
+
+
+@export
+class InfoMessage(metaclass=ExtendedType, mixin=True):
+	pass
+
+
+@export
+class WarningMessage(metaclass=ExtendedType, mixin=True):
+	pass
+
+
+@export
+class CriticalWarningMessage(metaclass=ExtendedType, mixin=True):
+	pass
+
+
+@export
+class ErrorMessage(metaclass=ExtendedType, mixin=True):
+	pass
+
+
+@export
+class VivadoMessage(Line):
+	"""
+	This class represents an AMD/Xilinx Vivado message.
+
+	The usual message format is:
+
+	.. code-block:: text
+
+	   INFO: [Synth 8-7079] Multithreading enabled for synth_design using a maximum of 2 processes.
+	   WARNING: [Synth 8-3332] Sequential element (gen[0].Sync/FF2) is unused and will be removed from module sync_Bits_Xilinx.
+
+	The following message severities are defined:
+
+	* ``INFO``
+	* ``WARNING``
+	* ``CRITICAL WARNING``
+	* ``ERROR``
+
+	.. seealso::
+
+	   :class:`VivadoInfoMessage`
+	     Representing a Vivado info message.
+
+	   :class:`VivadoWarningMessage`
+	     Representing a Vivado warning message.
+
+	   :class:`VivadoCriticalWarningMessage`
+	     Representing a Vivado critical warning message.
+
+	   :class:`VivadoErrorMessage`
+	     Representing a Vivado error message.
+	"""
+	# _MESSAGE_KIND:  ClassVar[str]
+	# _REGEXP:        ClassVar[Pattern]
+
+	_toolID:        int
+	_toolName:      str
+	_messageKindID: int
+
+	def __init__(self, lineNumber: int, kind: LineKind, tool: str, toolID: int, messageKindID: int, message: str) -> None:
+		super().__init__(lineNumber, kind, message)
+		self._toolID = toolID
+		self._toolName = tool
+		self._messageKindID = messageKindID
+
+	@readonly
+	def ToolName(self) -> str:
+		return self._toolName
+
+	@readonly
+	def ToolID(self) -> int:
+		return self._toolID
+
+	@readonly
+	def MessageKindID(self) -> int:
+		return self._messageKindID
+
+	@classmethod
+	def Parse(cls, lineNumber: int, kind: LineKind, rawMessage: str) -> Nullable[Self]:
+		if (match := cls._REGEXP.match(rawMessage)) is not None:
+			return cls(lineNumber, kind, match[1], int(match[2]), int(match[3]), match[4])
+
+		return None
+
+	def __str__(self) -> str:
+		return f"{self._MESSAGE_KIND}: [{self._toolName} {self._toolID}-{self._messageKindID}] {self._message}"
+
+
+@export
+class VivadoInfoMessage(VivadoMessage, InfoMessage):
+	"""
+	This class represents an AMD/Xilinx Vivado info message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "INFO"
+	_REGEXP:       ClassVar[Pattern] = re_compile(r"""INFO: \[(\w+) (\d+)-(\d+)\] (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		return super().Parse(lineNumber, LineKind.InfoMessage, rawMessage)
+
+
+@export
+class VivadoIrregularInfoMessage(VivadoMessage, InfoMessage):
+	"""
+	This class represents an irregular AMD/Xilinx Vivado info message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "INFO"
+	_REGEXP:      ClassVar[Pattern] = re_compile(r"""INFO: \[(\w+)-(\d+)\] (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		if (match := cls._REGEXP.match(rawMessage)) is not None:
+			return cls(lineNumber, LineKind.InfoMessage, match[1], None, int(match[2]), match[3])
+
+		return None
+
+	def __str__(self) -> str:
+		return f"{self._MESSAGE_KIND}: [{self._toolName}-{self._messageKindID}] {self._message}"
+
+
+@export
+class VivadoWarningMessage(VivadoMessage, WarningMessage):
+	"""
+	This class represents an AMD/Xilinx Vivado warning message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "WARNING"
+	_REGEXP:       ClassVar[Pattern] = re_compile(r"""WARNING: \[(\w+) (\d+)-(\d+)\] (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		return super().Parse(lineNumber, LineKind.WarningMessage, rawMessage)
+
+
+@export
+class VivadoIrregularWarningMessage(VivadoMessage, WarningMessage):
+	"""
+	This class represents an AMD/Xilinx Vivado warning message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "WARNING"
+	_REGEXP:       ClassVar[Pattern] = re_compile(r"""WARNING: (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		if (match := cls._REGEXP.match(rawMessage)) is not None:
+			return cls(lineNumber, LineKind.WarningMessage, None, None, None, match[1])
+
+		return None
+
+	def __str__(self) -> str:
+		return f"{self._MESSAGE_KIND}: {self._message}"
+
+
+@export
+class VivadoCriticalWarningMessage(VivadoMessage, CriticalWarningMessage):
+	"""
+	This class represents an AMD/Xilinx Vivado critical warning message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "CRITICAL WARNING"
+	_REGEXP:       ClassVar[Pattern] = re_compile(r"""CRITICAL WARNING: \[(\w+) (\d+)-(\d+)\] (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		return super().Parse(lineNumber, LineKind.CriticalWarningMessage, rawMessage)
+
+
+@export
+class VivadoErrorMessage(VivadoMessage, ErrorMessage):
+	"""
+	This class represents an AMD/Xilinx Vivado error message.
+	"""
+
+	_MESSAGE_KIND: ClassVar[str] =     "ERROR"
+	_REGEXP:       ClassVar[Pattern] = re_compile(r"""ERROR: \[(\w+) (\d+)-(\d+)\] (.*)""")
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		return super().Parse(lineNumber, LineKind.ErrorMessage, rawMessage)
+
+
+@export
+class VHDLReportMessage(VivadoInfoMessage):
+	_REGEXP: ClassVar[Pattern ] = re_compile(r"""RTL report: "(.*)" \[(.*):(\d+)\]""")
+
+	_reportMessage:    str
+	_sourceFile:       Path
+	_sourceLineNumber: int
+
+	def __init__(self, lineNumber: int, tool: str, toolID: int, messageKindID: int, rawMessage: str, reportMessage: str, sourceFile: Path, sourceLineNumber: int):
+		super().__init__(lineNumber, LineKind.InfoMessage, tool, toolID, messageKindID, rawMessage)
+
+		self._reportMessage = reportMessage
+		self._sourceFile = sourceFile
+		self._sourceLineNumber = sourceLineNumber
+
+	@classmethod
+	def Convert(cls, line: VivadoInfoMessage) -> Nullable[Self]:
+		if (match := cls._REGEXP.match(line._message)) is not None:
+			return cls(line._lineNumber, line._toolName, line._toolID, line._messageKindID, line._message, match[1], Path(match[2]), int(match[3]))
+
+		return None
+
+
+@export
+class VHDLAssertionMessage(VHDLReportMessage):
+	_REGEXP: ClassVar[Pattern ] = re_compile(r"""RTL assertion: "(.*)" \[(.*):(\d+)\]""")
+
+
+@export
+class TclCommand(Line):
+	_command: str
+	_args:    Tuple[str, ...]
+
+	def __init__(self, lineNumber: int, command: str, arguments: Tuple[str, ...], tclCommand: str) -> None:
+		super().__init__(lineNumber, LineKind.GenericTclCommand, tclCommand)
+
+		self._command = command
+		self._args = arguments
+
+	@readonly
+	def Command(self) -> str:
+		return self._command
+
+	@readonly
+	def Arguments(self) -> Tuple[str]:
+		return self._args
+
+	@classmethod
+	def FromLine(cls, line: Line) -> Nullable[Self]:
+		args = line._message.split()
+
+		return cls(line._lineNumber, args[0], tuple(args[1:]), line._message)
+
+	def __str__(self) -> str:
+		return f"{self._command} {' '.join(self._args)}"
+
+
+@export
+class VivadoTclCommand(TclCommand):
+	_PREFIX: ClassVar[str] = "Command:"
+
+	@classmethod
+	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
+		command = rawMessage[len(cls._PREFIX) + 1:]
+		args = command.split()
+
+		command = cls(lineNumber, args[0], tuple(args[1:]), command)
+		command._kind = LineKind.VivadoTclCommand
+		return command
+
+	def __str__(self) -> str:
+		return f"{self._PREFIX} {self._command} {' '.join(self._args)}"

--- a/pyEDAA/OutputFilter/Xilinx/Common.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common.py
@@ -102,11 +102,15 @@ class Line(metaclass=ExtendedType, slots=True):
 	_lineNumber:    int
 	_kind:          LineKind
 	_message:       str
+	_previousLine:  "Line"
+	_nextLine:      "Line"
 
 	def __init__(self, lineNumber: int, kind: LineKind, message: str) -> None:
-		self._lineNumber = lineNumber
-		self._kind = kind
-		self._message = message
+		self._lineNumber =   lineNumber
+		self._kind =         kind
+		self._message =      message
+		self._previousLine = None
+		self._nextLine =     None
 
 	@readonly
 	def LineNumber(self) -> int:
@@ -119,6 +123,20 @@ class Line(metaclass=ExtendedType, slots=True):
 	@readonly
 	def Message(self) -> str:
 		return self._message
+
+	@property
+	def PreviousLine(self) -> "Line":
+		return self._previousLine
+
+	@PreviousLine.setter
+	def PreviousLine(self, line: "Line") -> None:
+		self._previousLine = line
+		if line is not None:
+			line._nextLine = self
+
+	@readonly
+	def NextLine(self) -> "Line":
+		return self._nextLine
 
 	def Partition(self, separator: str) -> Tuple[str, str, str]:
 		return self._message.partition(separator)

--- a/pyEDAA/OutputFilter/Xilinx/Common.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common.py
@@ -70,26 +70,31 @@ class LineKind(Flag):
 	CriticalWarningMessage = Message | CriticalWarning
 	ErrorMessage =           Message | Error
 
-	Section =                2**31
+	Phase =                  2**31
+	PhaseDelimiter =         Phase | Delimiter
+	PhaseStart =             Phase | Start
+	PhaseEnd =               Phase | End
+
+	Section =                2**32
 	SectionDelimiter =       Section | Delimiter
 	SectionStart =           Section | Start
 	SectionEnd =             Section | End
 
-	SubSection =             2**32
+	SubSection =             2**33
 	SubSectionDelimiter =    SubSection | Delimiter
 	SubSectionStart =        SubSection | Start
 	SubSectionEnd =          SubSection | End
 
-	Paragraph =              2**33
+	Paragraph =              2**34
 	ParagraphHeadline =      Paragraph | Header
 
-	Table =                  2**34
+	Table =                  2**35
 	TableFrame =             Table | Delimiter
 	TableHeader =            Table | Header
 	TableRow =               Table | Content
 	TableFooter =            Table | Footer
 
-	TclCommand =             2 ** 35
+	TclCommand =             2 ** 36
 	GenericTclCommand =      TclCommand | 2**0
 	VivadoTclCommand =       TclCommand | 2**1
 

--- a/pyEDAA/OutputFilter/Xilinx/Common2.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common2.py
@@ -37,8 +37,8 @@ from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType
 from pyTooling.Versioning  import YearReleaseVersion
 
-from pyEDAA.OutputFilter.Xilinx import Line, LineKind, VivadoInfoMessage, VivadoWarningMessage, \
-	VivadoCriticalWarningMessage, VivadoErrorMessage, VivadoMessage
+from pyEDAA.OutputFilter.Xilinx import Line, LineKind, VivadoMessage
+from pyEDAA.OutputFilter.Xilinx import VivadoInfoMessage, VivadoWarningMessage, VivadoCriticalWarningMessage, VivadoErrorMessage
 
 
 @export
@@ -88,7 +88,16 @@ class VivadoMessagesMixin(metaclass=ExtendedType, mixin=True):
 	def ErrorMessages(self) -> List[VivadoErrorMessage]:
 		return self._errorMessages
 
-	def _AddMessageByID(self, message: VivadoMessage) -> None:
+	def _AddMessage(self, message: VivadoMessage) -> None:
+		if isinstance(message, VivadoInfoMessage):
+			self._infoMessages.append(message)
+		elif isinstance(message, VivadoWarningMessage):
+			self._warningMessages.append(message)
+		elif isinstance(message, VivadoCriticalWarningMessage):
+			self._criticalWarningMessages.append(message)
+		elif isinstance(message, VivadoErrorMessage):
+			self._errorMessages.append(message)
+
 		if message._toolID in self._messagesByID:
 			sub = self._messagesByID[message._toolID]
 			if message._messageKindID in sub:

--- a/pyEDAA/OutputFilter/Xilinx/Common2.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common2.py
@@ -153,24 +153,21 @@ class Preamble(Parser):
 		return self._startDatetime
 
 	def Generator(self, line: Line) -> Generator[Line, Line, Line]:
-		rawMessage = line._message
-		if rawMessage.startswith("#----"):
+		if line.StartsWith("#----"):
 			line._kind = LineKind.SectionDelimiter
 		else:
 			line._kind |= LineKind.ProcessorError
 
 		line = yield line
 
-		while line is not None:
-			rawMessage = line._message
-
-			if (match := self._VERSION.match(rawMessage)) is not None:
+		while True:
+			if (match := self._VERSION.match(line._message)) is not None:
 				self._toolVersion = YearReleaseVersion.Parse(match[1])
 				line._kind = LineKind.Normal
-			elif (match := self._STARTTIME.match(rawMessage)) is not None:
+			elif (match := self._STARTTIME.match(line._message)) is not None:
 				self._startDatetime = datetime.strptime(match[1], "%a %b %d %H:%M:%S %Y")
 				line._kind = LineKind.Normal
-			elif rawMessage.startswith("#----"):
+			elif line.StartsWith("#----"):
 				line._kind = LineKind.SectionDelimiter | LineKind.Last
 				break
 			else:

--- a/pyEDAA/OutputFilter/Xilinx/Common2.py
+++ b/pyEDAA/OutputFilter/Xilinx/Common2.py
@@ -1,0 +1,108 @@
+# ==================================================================================================================== #
+#               _____ ____    _        _      ___        _               _   _____ _ _ _                               #
+#   _ __  _   _| ____|  _ \  / \      / \    / _ \ _   _| |_ _ __  _   _| |_|  ___(_) | |_ ___ _ __                    #
+#  | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | | | | __| '_ \| | | | __| |_  | | | __/ _ \ '__|                   #
+#  | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |_| | |_| |_) | |_| | |_|  _| | | | ||  __/ |                      #
+#  | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \__,_|\__| .__/ \__,_|\__|_|   |_|_|\__\___|_|                      #
+#  |_|    |___/                                             |_|                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2025-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Basic classes for outputs from AMD/Xilinx Vivado."""
+from datetime import datetime
+from re       import Pattern, compile as re_compile
+from typing   import ClassVar, Optional as Nullable, Generator
+
+from pyTooling.Decorators  import export, readonly
+from pyTooling.MetaClasses import ExtendedType
+from pyTooling.Versioning  import YearReleaseVersion
+
+from pyEDAA.OutputFilter.Xilinx import Line, LineKind
+
+
+@export
+class BaseParser(metaclass=ExtendedType, slots=True):
+	pass
+
+@export
+class Parser(BaseParser):
+	_processor: "Processor"
+
+	def __init__(self, processor: "Processor"):
+		self._processor = processor
+
+	@readonly
+	def Processor(self) -> "Processor":
+		return self._processor
+
+
+@export
+class Preamble(Parser):
+	_toolVersion:   Nullable[YearReleaseVersion]
+	_startDatetime: Nullable[datetime]
+
+	_VERSION:   ClassVar[Pattern] = re_compile(r"""# Vivado v(\d+\.\d(\.\d)?) \(64-bit\)""")
+	_STARTTIME: ClassVar[Pattern] = re_compile(r"""# Start of session at: (\w+ \w+ \d+ \d+:\d+:\d+ \d+)""")
+
+	def __init__(self, processor: "BaseProcessor"):
+		super().__init__(processor)
+
+		self._toolVersion =   None
+		self._startDatetime = None
+
+	@readonly
+	def ToolVersion(self) -> YearReleaseVersion:
+		return self._toolVersion
+
+	@readonly
+	def StartDatetime(self) -> datetime:
+		return self._startDatetime
+
+	def Generator(self, line: Line) -> Generator[Line, Line, Line]:
+		rawMessage = line._message
+		if rawMessage.startswith("#----"):
+			line._kind = LineKind.SectionDelimiter
+		else:
+			line._kind |= LineKind.ProcessorError
+
+		line = yield line
+
+		while line is not None:
+			rawMessage = line._message
+
+			if (match := self._VERSION.match(rawMessage)) is not None:
+				self._toolVersion = YearReleaseVersion.Parse(match[1])
+				line._kind = LineKind.Normal
+			elif (match := self._STARTTIME.match(rawMessage)) is not None:
+				self._startDatetime = datetime.strptime(match[1], "%a %b %d %H:%M:%S %Y")
+				line._kind = LineKind.Normal
+			elif rawMessage.startswith("#----"):
+				line._kind = LineKind.SectionDelimiter | LineKind.Last
+				break
+			else:
+				line._kind = LineKind.Verbose
+
+			line = yield line
+
+		nextLine = yield line
+		return nextLine

--- a/pyEDAA/OutputFilter/Xilinx/Exception.py
+++ b/pyEDAA/OutputFilter/Xilinx/Exception.py
@@ -1,0 +1,56 @@
+# ==================================================================================================================== #
+#               _____ ____    _        _      ___        _               _   _____ _ _ _                               #
+#   _ __  _   _| ____|  _ \  / \      / \    / _ \ _   _| |_ _ __  _   _| |_|  ___(_) | |_ ___ _ __                    #
+#  | '_ \| | | |  _| | | | |/ _ \    / _ \  | | | | | | | __| '_ \| | | | __| |_  | | | __/ _ \ '__|                   #
+#  | |_) | |_| | |___| |_| / ___ \  / ___ \ | |_| | |_| | |_| |_) | |_| | |_|  _| | | | ||  __/ |                      #
+#  | .__/ \__, |_____|____/_/   \_\/_/   \_(_)___/ \__,_|\__| .__/ \__,_|\__|_|   |_|_|\__\___|_|                      #
+#  |_|    |___/                                             |_|                                                        #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2025-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""Basic classes for outputs from AMD/Xilinx Vivado."""
+from pyTooling.Decorators import export
+
+from pyEDAA.OutputFilter  import OutputFilterException
+
+
+@export
+class ProcessorException(OutputFilterException):
+	pass
+
+
+@export
+class ClassificationException(ProcessorException):
+	_lineNumber: int
+	_rawMessage: str
+
+	def __init__(self, errorMessage: str, lineNumber: int, rawMessageLine: str):
+		super().__init__(errorMessage)
+
+		self._lineNumber = lineNumber
+		self._rawMessage = rawMessageLine
+
+
+@export
+class ParserStateException(ProcessorException):
+	pass

--- a/pyEDAA/OutputFilter/Xilinx/Exception.py
+++ b/pyEDAA/OutputFilter/Xilinx/Exception.py
@@ -50,6 +50,9 @@ class ClassificationException(ProcessorException):
 		self._lineNumber = lineNumber
 		self._rawMessage = rawMessageLine
 
+	def __str__(self) -> str:
+		return f"{self.message}: {self._rawMessage} (at line {self._lineNumber})"
+
 
 @export
 class ParserStateException(ProcessorException):

--- a/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
+++ b/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
@@ -171,6 +171,12 @@ class SubSection(BaseParser, BaseSection):
 		return nextLine
 
 	def _SectionFinish(self, line: Line) -> Generator[Line, Line, None]:
+		if line.StartsWith("----"):
+			line._kind = LineKind.SubSectionEnd | LineKind.SubSectionDelimiter
+		else:
+			line._kind |= LineKind.ProcessorError
+
+		line = yield line
 		if line.StartsWith(self._FINISH):
 			line._kind = LineKind.SubSectionEnd
 		else:
@@ -189,9 +195,7 @@ class SubSection(BaseParser, BaseSection):
 		line = yield from self._SectionStart(line)
 
 		while line is not None:
-			rawMessage = line._message
-
-			if rawMessage.startswith("----"):
+			if line.StartsWith("----"):
 				line._kind = LineKind.SubSectionEnd | LineKind.SubSectionDelimiter
 				break
 			else:
@@ -199,9 +203,7 @@ class SubSection(BaseParser, BaseSection):
 
 			line = yield line
 
-		line = yield line
 		nextLine = yield from self._SectionFinish(line)
-
 		return nextLine
 
 

--- a/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
+++ b/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
@@ -334,6 +334,12 @@ class CrossBoundaryAndAreaOptimization(Section):
 
 
 @export
+class ROM_RAM_DSP_SR_Retiming1(Section):
+	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
+	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
+
+
+@export
 class ApplyingXDCTimingConstraints(Section):
 	_START:  ClassVar[str] = "Start Applying XDC Timing Constraints"
 	_FINISH: ClassVar[str] = "Finished Applying XDC Timing Constraints : "
@@ -343,6 +349,12 @@ class ApplyingXDCTimingConstraints(Section):
 class TimingOptimization(Section):
 	_START:  ClassVar[str] = "Start Timing Optimization"
 	_FINISH: ClassVar[str] = "Finished Timing Optimization : "
+
+
+@export
+class ROM_RAM_DSP_SR_Retiming2(Section):
+	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
+	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
 
 
 @export
@@ -400,6 +412,7 @@ class IOInsertion(Section):
 		nextLine = yield from self._SectionFinish(line)
 		return nextLine
 
+
 @export
 class RenamingGeneratedInstances(Section):
 	_START:  ClassVar[str] = "Start Renaming Generated Instances"
@@ -428,6 +441,12 @@ class HandlingCustomAttributes2(Section):
 class RenamingGeneratedNets(Section):
 	_START:  ClassVar[str] = "Start Renaming Generated Nets"
 	_FINISH: ClassVar[str] = "Finished Renaming Generated Nets : "
+
+
+@export
+class ROM_RAM_DSP_SR_Retiming3(Section):
+	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
+	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
 
 
 @export

--- a/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
+++ b/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
@@ -30,12 +30,13 @@
 #
 """A filtering anc classification processor for AMD/Xilinx Vivado Synthesis outputs."""
 from re       import compile as re_compile
-from typing   import ClassVar, Dict, Generator
+from typing   import ClassVar, Dict, Generator, List
 
 from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType, abstractmethod
 
-from pyEDAA.OutputFilter.Xilinx.Common import VHDLAssertionMessage, Line, LineKind, VivadoInfoMessage, VHDLReportMessage, VivadoMessage
+from pyEDAA.OutputFilter.Xilinx.Common import VHDLAssertionMessage, Line, LineKind, VivadoInfoMessage, \
+	VHDLReportMessage, VivadoMessage, VivadoWarningMessage, VivadoCriticalWarningMessage, VivadoErrorMessage
 from pyEDAA.OutputFilter.Xilinx.Common2 import BaseParser
 
 TIME_MEMORY_PATTERN = re_compile(r"""Time \(s\): cpu = (\d{2}:\d{2}:\d{2}) ; elapsed = (\d{2}:\d{2}:\d{2}) . Memory \(MB\): peak = (\d+\.\d+) ; gain = (\d+\.\d+)""")
@@ -244,7 +245,7 @@ class RTLElaboration(Section):
 
 
 @export
-class HandlingCustomAttributes1(Section):
+class HandlingCustomAttributes(Section):
 	_START:  ClassVar[str] = "Start Handling Custom Attributes"
 	_FINISH: ClassVar[str] = "Finished Handling Custom Attributes : "
 
@@ -334,7 +335,7 @@ class CrossBoundaryAndAreaOptimization(Section):
 
 
 @export
-class ROM_RAM_DSP_SR_Retiming1(Section):
+class ROM_RAM_DSP_SR_Retiming(Section):
 	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
 	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
 
@@ -349,12 +350,6 @@ class ApplyingXDCTimingConstraints(Section):
 class TimingOptimization(Section):
 	_START:  ClassVar[str] = "Start Timing Optimization"
 	_FINISH: ClassVar[str] = "Finished Timing Optimization : "
-
-
-@export
-class ROM_RAM_DSP_SR_Retiming2(Section):
-	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
-	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
 
 
 @export
@@ -432,21 +427,9 @@ class RenamingGeneratedPorts(Section):
 
 
 @export
-class HandlingCustomAttributes2(Section):
-	_START:  ClassVar[str] = "Start Handling Custom Attributes"
-	_FINISH: ClassVar[str] = "Finished Handling Custom Attributes : "
-
-
-@export
 class RenamingGeneratedNets(Section):
 	_START:  ClassVar[str] = "Start Renaming Generated Nets"
 	_FINISH: ClassVar[str] = "Finished Renaming Generated Nets : "
-
-
-@export
-class ROM_RAM_DSP_SR_Retiming3(Section):
-	_START:  ClassVar[str] = "Start ROM, RAM, DSP, Shift Register and Retiming Reporting"
-	_FINISH: ClassVar[str] = "Finished ROM, RAM, DSP, Shift Register and Retiming Reporting : "
 
 
 @export

--- a/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
+++ b/pyEDAA/OutputFilter/Xilinx/SynthesizeDesign.py
@@ -239,7 +239,9 @@ class RTLElaboration(Section):
 			if line.StartsWith("----"):
 				line._kind = LineKind.SectionEnd | LineKind.SectionDelimiter
 				break
-			elif not isinstance(line, VivadoMessage):
+			elif isinstance(line, VivadoMessage):
+				self._AddMessage(line)
+			else:
 				line._kind = LineKind.Verbose
 
 			line = yield line
@@ -288,7 +290,9 @@ class LoadingPart(Section):
 			if line.StartsWith("----"):
 				line._kind = LineKind.SectionEnd | LineKind.SectionDelimiter
 				break
-			elif not isinstance(line, VivadoMessage):
+			elif isinstance(line, VivadoMessage):
+				self._AddMessage(line)
+			else:
 				line._kind = LineKind.Verbose
 
 			line = yield line
@@ -314,7 +318,9 @@ class RTLComponentStatistics(Section):
 			if line.StartsWith("----"):
 				line._kind = LineKind.SectionEnd | LineKind.SectionDelimiter
 				break
-			elif not isinstance(line, VivadoMessage):
+			elif isinstance(line, VivadoMessage):
+				self._AddMessage(line)
+			else:
 				line._kind = LineKind.Verbose
 
 			line = yield line

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -29,379 +29,31 @@
 # ==================================================================================================================== #
 #
 """Basic classes for outputs from AMD/Xilinx Vivado."""
-from datetime import datetime
-from enum     import Flag
 from pathlib  import Path
-from re       import compile as re_compile, Pattern
-from typing import ClassVar, Self, Optional as Nullable, Dict, Type, Callable, List, Generator, Union, Tuple
+from typing import Optional as Nullable, Dict, List, Generator, Union, Type
 
 from pyTooling.Decorators  import export, readonly
-from pyTooling.MetaClasses import ExtendedType, abstractmethod
+from pyTooling.MetaClasses import ExtendedType
 from pyTooling.Stopwatch   import Stopwatch
-from pyTooling.TerminalUI  import TerminalApplication
-from pyTooling.Versioning  import YearReleaseVersion
 
-from pyEDAA.OutputFilter   import OutputFilterException
+from pyEDAA.OutputFilter.Xilinx.Common import LineKind, Line, InfoMessage, WarningMessage, CriticalWarningMessage, \
+	ErrorMessage, VivadoMessage, VivadoInfoMessage, VivadoIrregularInfoMessage, VivadoWarningMessage, \
+	VivadoIrregularWarningMessage, VivadoCriticalWarningMessage, VivadoErrorMessage, VHDLReportMessage, VivadoTclCommand, \
+	TclCommand
+from pyEDAA.OutputFilter.Xilinx.Commands import Command, SynthesizeDesign
+from pyEDAA.OutputFilter.Xilinx.Common2 import Preamble
+from pyEDAA.OutputFilter.Xilinx.Exception import ProcessorException, ClassificationException
 
 
-@export
-class ProcessorException(OutputFilterException):
-	pass
-
-
-@export
-class ClassificationException(ProcessorException):
-	_lineNumber: int
-	_rawMessage: str
-
-	def __init__(self, errorMessage: str, lineNumber: int, rawMessageLine: str):
-		super().__init__(errorMessage)
-
-		self._lineNumber = lineNumber
-		self._rawMessage = rawMessageLine
+ProcessedLine = Union[Line, ProcessorException]
 
 
 @export
-class ParserStateException(ProcessorException):
-	pass
-
-
-@export
-class LineKind(Flag):
-	Unprocessed =                0
-	ProcessorError =         2** 0
-	Empty =                  2** 1
-	Delimiter =              2** 2
-
-	Verbose =                2**10
-	Normal =                 2**11
-	Info =                   2**12
-	Warning =                2**13
-	CriticalWarning =        2**14
-	Error =                  2**15
-	Fatal =                  2**16
-
-	Start =                  2**20
-	End =                    2**21
-	Header =                 2**22
-	Content =                2**23
-	Footer =                 2**24
-
-	Last =                   2**29
-
-	Message =                2**30
-	InfoMessage =            Message | Info
-	WarningMessage =         Message | Warning
-	CriticalWarningMessage = Message | CriticalWarning
-	ErrorMessage =           Message | Error
-
-	Section =                2**31
-	SectionDelimiter =       Section | Delimiter
-	SectionStart =           Section | Start
-	SectionEnd =             Section | End
-
-	SubSection =             2**32
-	SubSectionDelimiter =    SubSection | Delimiter
-	SubSectionStart =        SubSection | Start
-	SubSectionEnd =          SubSection | End
-
-	Paragraph =              2**33
-	ParagraphHeadline =      Paragraph | Header
-
-	Table =                  2**34
-	TableFrame =             Table | Delimiter
-	TableHeader =            Table | Header
-	TableRow =               Table | Content
-	TableFooter =            Table | Footer
-
-	Command =                2**35
-
-
-@export
-class Line(metaclass=ExtendedType, slots=True):
-	"""
-	This class represents any line in a log file.
-	"""
-	_lineNumber:    int
-	_kind:          LineKind
-	_message:       str
-
-	def __init__(self, lineNumber: int, kind: LineKind, message: str) -> None:
-		self._lineNumber = lineNumber
-		self._kind = kind
-		self._message = message
-
-	@readonly
-	def LineNumber(self) -> int:
-		return self._lineNumber
-
-	@readonly
-	def Kind(self) -> LineKind:
-		return self._kind
-
-	@readonly
-	def Message(self) -> str:
-		return self._message
-
-	def __str__(self) -> str:
-		return self._message
-
-
-@export
-class InfoMessage(metaclass=ExtendedType, mixin=True):
-	pass
-
-
-@export
-class WarningMessage(metaclass=ExtendedType, mixin=True):
-	pass
-
-
-@export
-class CriticalWarningMessage(metaclass=ExtendedType, mixin=True):
-	pass
-
-
-@export
-class ErrorMessage(metaclass=ExtendedType, mixin=True):
-	pass
-
-
-@export
-class VivadoMessage(Line):
-	"""
-	This class represents an AMD/Xilinx Vivado message.
-
-	The usual message format is:
-
-	.. code-block:: text
-
-	   INFO: [Synth 8-7079] Multithreading enabled for synth_design using a maximum of 2 processes.
-	   WARNING: [Synth 8-3332] Sequential element (gen[0].Sync/FF2) is unused and will be removed from module sync_Bits_Xilinx.
-
-	The following message severities are defined:
-
-	* ``INFO``
-	* ``WARNING``
-	* ``CRITICAL WARNING``
-	* ``ERROR``
-
-	.. seealso::
-
-	   :class:`VivadoInfoMessage`
-	     Representing a Vivado info message.
-
-	   :class:`VivadoWarningMessage`
-	     Representing a Vivado warning message.
-
-	   :class:`VivadoCriticalWarningMessage`
-	     Representing a Vivado critical warning message.
-
-	   :class:`VivadoErrorMessage`
-	     Representing a Vivado error message.
-	"""
-	# _MESSAGE_KIND:  ClassVar[str]
-	# _REGEXP:        ClassVar[Pattern]
-
-	_toolID:        int
-	_toolName:      str
-	_messageKindID: int
-
-	def __init__(self, lineNumber: int, kind: LineKind, tool: str, toolID: int, messageKindID: int, message: str) -> None:
-		super().__init__(lineNumber, kind, message)
-		self._toolID = toolID
-		self._toolName = tool
-		self._messageKindID = messageKindID
-
-	@readonly
-	def ToolName(self) -> str:
-		return self._toolName
-
-	@readonly
-	def ToolID(self) -> int:
-		return self._toolID
-
-	@readonly
-	def MessageKindID(self) -> int:
-		return self._messageKindID
-
-	@classmethod
-	def Parse(cls, lineNumber: int, kind: LineKind, rawMessage: str) -> Nullable[Self]:
-		if (match := cls._REGEXP.match(rawMessage)) is not None:
-			return cls(lineNumber, kind, match[1], int(match[2]), int(match[3]), match[4])
-
-		return None
-
-	def __str__(self) -> str:
-		return f"{self._MESSAGE_KIND}: [{self._toolName} {self._toolID}-{self._messageKindID}] {self._message}"
-
-
-@export
-class VivadoInfoMessage(VivadoMessage, InfoMessage):
-	"""
-	This class represents an AMD/Xilinx Vivado info message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "INFO"
-	_REGEXP:       ClassVar[Pattern] = re_compile(r"""INFO: \[(\w+) (\d+)-(\d+)\] (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		return super().Parse(lineNumber, LineKind.InfoMessage, rawMessage)
-
-
-@export
-class VivadoIrregularInfoMessage(VivadoMessage, InfoMessage):
-	"""
-	This class represents an irregular AMD/Xilinx Vivado info message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "INFO"
-	_REGEXP:      ClassVar[Pattern] = re_compile(r"""INFO: \[(\w+)-(\d+)\] (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		if (match := cls._REGEXP.match(rawMessage)) is not None:
-			return cls(lineNumber, LineKind.InfoMessage, match[1], None, int(match[2]), match[3])
-
-		return None
-
-	def __str__(self) -> str:
-		return f"{self._MESSAGE_KIND}: [{self._toolName}-{self._messageKindID}] {self._message}"
-
-
-@export
-class VivadoWarningMessage(VivadoMessage, WarningMessage):
-	"""
-	This class represents an AMD/Xilinx Vivado warning message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "WARNING"
-	_REGEXP:       ClassVar[Pattern] = re_compile(r"""WARNING: \[(\w+) (\d+)-(\d+)\] (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		return super().Parse(lineNumber, LineKind.WarningMessage, rawMessage)
-
-
-@export
-class VivadoIrregularWarningMessage(VivadoMessage, WarningMessage):
-	"""
-	This class represents an AMD/Xilinx Vivado warning message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "WARNING"
-	_REGEXP:       ClassVar[Pattern] = re_compile(r"""WARNING: (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		if (match := cls._REGEXP.match(rawMessage)) is not None:
-			return cls(lineNumber, LineKind.WarningMessage, None, None, None, match[1])
-
-		return None
-
-	def __str__(self) -> str:
-		return f"{self._MESSAGE_KIND}: {self._message}"
-
-
-@export
-class VivadoCriticalWarningMessage(VivadoMessage, CriticalWarningMessage):
-	"""
-	This class represents an AMD/Xilinx Vivado critical warning message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "CRITICAL WARNING"
-	_REGEXP:       ClassVar[Pattern] = re_compile(r"""CRITICAL WARNING: \[(\w+) (\d+)-(\d+)\] (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		return super().Parse(lineNumber, LineKind.CriticalWarningMessage, rawMessage)
-
-
-@export
-class VivadoErrorMessage(VivadoMessage, ErrorMessage):
-	"""
-	This class represents an AMD/Xilinx Vivado error message.
-	"""
-
-	_MESSAGE_KIND: ClassVar[str] =     "ERROR"
-	_REGEXP:       ClassVar[Pattern] = re_compile(r"""ERROR: \[(\w+) (\d+)-(\d+)\] (.*)""")
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		return super().Parse(lineNumber, LineKind.ErrorMessage, rawMessage)
-
-
-@export
-class VHDLReportMessage(VivadoInfoMessage):
-	_REGEXP: ClassVar[Pattern ] = re_compile(r"""RTL report: "(.*)" \[(.*):(\d+)\]""")
-
-	_reportMessage:    str
-	_sourceFile:       Path
-	_sourceLineNumber: int
-
-	def __init__(self, lineNumber: int, tool: str, toolID: int, messageKindID: int, rawMessage: str, reportMessage: str, sourceFile: Path, sourceLineNumber: int):
-		super().__init__(lineNumber, LineKind.InfoMessage, tool, toolID, messageKindID, rawMessage)
-
-		self._reportMessage = reportMessage
-		self._sourceFile = sourceFile
-		self._sourceLineNumber = sourceLineNumber
-
-	@classmethod
-	def Convert(cls, line: VivadoInfoMessage) -> Nullable[Self]:
-		if (match := cls._REGEXP.match(line._message)) is not None:
-			return cls(line._lineNumber, line._toolName, line._toolID, line._messageKindID, line._message, match[1], Path(match[2]), int(match[3]))
-
-		return None
-
-
-@export
-class VHDLAssertionMessage(VHDLReportMessage):
-	_REGEXP: ClassVar[Pattern ] = re_compile(r"""RTL assertion: "(.*)" \[(.*):(\d+)\]""")
-
-
-@export
-class VivadoTclCommand(Line):
-	_PREFIX: ClassVar[str] = "Command:"
-
-	_command: str
-	_args:    Tuple[str, ...]
-
-	def __init__(self, lineNumber: int, command: str, arguments: Tuple[str, ...], tclCommand: str) -> None:
-		super().__init__(lineNumber, LineKind.Command, tclCommand)
-
-		self._command = command
-		self._args = arguments
-
-	@classmethod
-	def Parse(cls, lineNumber: int, rawMessage: str) -> Nullable[Self]:
-		command = rawMessage[len(cls._PREFIX) + 1:]
-		args = command.split()
-
-		return cls(lineNumber, args[0], tuple(args[1:]), command)
-
-	def __str__(self) -> str:
-		return f"{self._PREFIX} {self._command} {' '.join(self._args)}"
-
-
-@export
-class ProcessingState(Flag):
-	Processed =        1
-	Skipped =          2
-	EmptyLine =        4
-	CommentLine =      8
-	DelimiterLine =   16
-	TableLine =       32
-	TableHeader =     64
-	Reprocess =      512
-	Last =          1024
-
-
-@export
-class BaseProcessor(metaclass=ExtendedType, slots=True):
-	# _parsers:  Dict[Type["Parser"], "Parsers"]
-	# _state:    Callable[[int, str], bool]
-	_duration: float
+class Processor(metaclass=ExtendedType, slots=True):
+	_duration:                float
+
+	_preamble:                Preamble
+	_commands:                Dict[Type[Command], Command]
 
 	_infoMessages:            List[VivadoInfoMessage]
 	_warningMessages:         List[VivadoWarningMessage]
@@ -412,9 +64,10 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 	_messagesByID:            Dict[int, Dict[int, List[VivadoMessage]]]
 
 	def __init__(self):
-		# self._parsers =  {}
-		# self._state =    None
-		self._duration = 0.0
+		self._duration =                0.0
+
+		self._preamble =                None
+		self._commands =                {}
 
 		self._infoMessages =            []
 		self._warningMessages =         []
@@ -456,6 +109,7 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 	def ErrorMessages(self) -> List[VivadoErrorMessage]:
 		return self._errorMessages
 
+	# TODO: Synthesis specific !!
 	@readonly
 	def VHDLReportMessages(self) -> List[VHDLReportMessage]:
 		if 8 in self._messagesByID:
@@ -472,8 +126,8 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 
 		return []
 
-	# def __getitem__(self, item: Type["Parser"]) -> "Parsers":
-	# 	return self._parsers[item]
+	def __getitem__(self, item: Type[Command]) -> Command:
+		return self._commands[item]
 
 	def _AddMessageByID(self, message: VivadoMessage) -> None:
 		if message._toolID in self._messagesByID:
@@ -487,15 +141,14 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 			self._toolNames[message._toolName] = message._toolID
 			self._messagesByID[message._toolID] = {message._messageKindID: [message]}
 
-	def LineClassification(self, documentSlicer: Generator[Union[Line, ProcessorException], Line, None]) -> Generator[Union[Line, ProcessorException], str, None]:
-		# Initialize generator
-		next(documentSlicer)
+	def LineClassification(self) -> Generator[ProcessedLine, str, None]:
+		# Instantiate and initialize CommandFinder
+		next(cmdFinder := self.CommandFinder())
 
 		# wait for first line
 		rawMessageLine = yield
 		lineNumber = 0
 		_errorMessage = "Unknown processing error."
-		errorMessage = _errorMessage
 
 		while rawMessageLine is not None:
 			lineNumber += 1
@@ -531,7 +184,7 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 			if line is None:
 				line = Line(lineNumber, LineKind.ProcessorError, rawMessageLine)
 
-			line = documentSlicer.send(line)
+			line = cmdFinder.send(line)
 
 			if isinstance(line, VivadoMessage):
 				self._AddMessageByID(line)
@@ -549,75 +202,46 @@ class BaseProcessor(metaclass=ExtendedType, slots=True):
 
 			rawMessageLine = yield line
 
+	def CommandFinder(self) -> Generator[Line, Line, None]:
+		self._preamble = Preamble(self)
+		cmd = None
 
-@export
-class Parser(metaclass=ExtendedType, slots=True):
-	_processor: "BaseProcessor"
+		tclProcedures = {"source"}
 
-	def __init__(self, processor: "BaseProcessor"):
-		self._processor = processor
+		# wait for first line
+		line = yield
+		# process preable
+		line = yield from self._preamble.Generator(line)
 
-	@readonly
-	def Processor(self) -> "BaseProcessor":
-		return self._processor
+		while True:
+			while True:
+				if isinstance(line, VivadoTclCommand):
+					if line._command == "synth_design":
+						self._commands[SynthesizeDesign] = (cmd := SynthesizeDesign(self))
+						line = yield next(gen := cmd.SectionDetector(line))
+						break
 
+				firstWord = line.Partition(" ")[0]
+				if firstWord in tclProcedures:
+					line = TclCommand.FromLine(line)
 
-@export
-class Preamble(Parser):
-	_toolVersion:   Nullable[YearReleaseVersion]
-	_startDatetime: Nullable[datetime]
+				line = yield line
 
-	_VERSION:   ClassVar[Pattern] = re_compile(r"""# Vivado v(\d+\.\d(\.\d)?) \(64-bit\)""")
-	_STARTTIME: ClassVar[Pattern] = re_compile(r"""# Start of session at: (\w+ \w+ \d+ \d+:\d+:\d+ \d+)""")
+			while True:
+				if line.StartsWith("synth_design:"):
+					lastLine = gen.send(line)
+					if LineKind.Last in line._kind:
+						line._kind ^= LineKind.Last
+					line = yield lastLine
+					break
 
-	def __init__(self, processor: "BaseProcessor"):
-		super().__init__(processor)
-
-		self._toolVersion =   None
-		self._startDatetime = None
-
-	@readonly
-	def ToolVersion(self) -> YearReleaseVersion:
-		return self._toolVersion
-
-	@readonly
-	def StartDatetime(self) -> datetime:
-		return self._startDatetime
-
-	def Generator(self, line: Line) -> Generator[Line, Line, Line]:
-		rawMessage = line._message
-		if rawMessage.startswith("#----"):
-			line._kind = LineKind.SectionDelimiter
-		else:
-			line._kind |= LineKind.ProcessorError
-
-		line = yield line
-
-		while line is not None:
-			rawMessage = line._message
-
-			if (match := self._VERSION.match(rawMessage)) is not None:
-				self._toolVersion = YearReleaseVersion.Parse(match[1])
-				line._kind = LineKind.Normal
-			elif (match := self._STARTTIME.match(rawMessage)) is not None:
-				self._startDatetime = datetime.strptime(match[1], "%a %b %d %H:%M:%S %Y")
-				line._kind = LineKind.Normal
-			elif rawMessage.startswith("#----"):
-				line._kind = LineKind.SectionDelimiter | LineKind.Last
-				break
-			else:
-				line._kind = LineKind.Verbose
-
-			line = yield line
-
-		check = yield line
+				line = yield gen.send(line)
 
 
 @export
-class BaseDocument(BaseProcessor):
+class Document(Processor):
 	_logfile: Path
 	_lines:   List[Line]
-	# _duration: float
 
 	def __init__(self, logfile: Path) -> None:
 		super().__init__()
@@ -630,15 +254,10 @@ class BaseDocument(BaseProcessor):
 			with self._logfile.open("r", encoding="utf-8") as f:
 				content = f.read()
 
-			lines = content.splitlines()
-			next(generator := self.LineClassification(self.DocumentSlicer()))
-			self._lines = [generator.send(rawLine) for rawLine in lines]
+			self._lines = []
+			next(generator := self.LineClassification())
+			for rawLine in content.splitlines():
+				line = generator.send(rawLine)
+				self._lines.append(line)
 
 		self._duration = sw.Duration
-
-	def DocumentSlicer(self, line: Line) -> Generator[Union[Line, ProcessorException], Line, Line]:
-		while line is not None:
-			if line._kind is LineKind.Unprocessed:
-				line._kind = LineKind.Normal
-
-			line = yield line

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -86,6 +86,7 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 		next(cmdFinder := self.CommandFinder())
 
 		# wait for first line
+		lastLine = None
 		rawMessageLine = yield
 		lineNumber = 0
 		_errorMessage = "Unknown processing error."
@@ -124,6 +125,8 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 			if line is None:
 				line = Line(lineNumber, LineKind.ProcessorError, rawMessageLine)
 
+			line.PreviousLine = lastLine
+			lastLine = line
 			line = cmdFinder.send(line)
 
 			if isinstance(line, VivadoMessage):

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -78,6 +78,14 @@ class Processor(metaclass=ExtendedType, slots=True):
 		self._messagesByID =            {}
 
 	@readonly
+	def Preamble(self) -> Preamble:
+		return self._preamble
+
+	@readonly
+	def Commands(self) -> Dict[Type[Command], Command]:
+		return self._commands
+
+	@readonly
 	def Duration(self) -> float:
 		return self._duration
 

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -81,6 +81,17 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 	def __getitem__(self, item: Type[Command]) -> Command:
 		return self._commands[item]
 
+	def IsIncompleteLog(self) -> bool:
+		"""
+
+		:return:
+
+		.. info::
+
+		   ``INFO: [Common 17-14] Message 'Synth 8-3321' appears 100 times and further instances of the messages will be disabled. Use the Tcl command set_msg_config to change the current settings.``
+		"""
+		return 17 in self._messagesByID and 14 in self._messagesByID[17]
+
 	def LineClassification(self) -> Generator[ProcessedLine, str, None]:
 		# Instantiate and initialize CommandFinder
 		next(cmdFinder := self.CommandFinder())
@@ -130,7 +141,7 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 			line = cmdFinder.send(line)
 
 			if isinstance(line, VivadoMessage):
-				self._AddMessageByID(line)
+				self._AddMessage(line)
 				if isinstance(line, InfoMessage):
 					self._infoMessages.append(line)
 				elif isinstance(line, WarningMessage):

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -100,7 +100,7 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 		lastLine = None
 		rawMessageLine = yield
 		lineNumber = 0
-		_errorMessage = "Unknown processing error."
+		_errorMessage = "Unknown processing error"
 
 		while rawMessageLine is not None:
 			lineNumber += 1
@@ -142,17 +142,9 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 
 			if isinstance(line, VivadoMessage):
 				self._AddMessage(line)
-				if isinstance(line, InfoMessage):
-					self._infoMessages.append(line)
-				elif isinstance(line, WarningMessage):
-					self._warningMessages.append(line)
-				elif isinstance(line, CriticalWarningMessage):
-					self._criticalWarningMessages.append(line)
-				elif isinstance(line, ErrorMessage):
-					self._errorMessages.append(line)
 
 			if line._kind is LineKind.ProcessorError:
-				line = ClassificationException(errorMessage, rawMessageLine, line)
+				line = ClassificationException(errorMessage, lineNumber, rawMessageLine)
 
 			rawMessageLine = yield line
 

--- a/pyEDAA/OutputFilter/Xilinx/__init__.py
+++ b/pyEDAA/OutputFilter/Xilinx/__init__.py
@@ -118,9 +118,9 @@ class Processor(VivadoMessagesMixin, metaclass=ExtendedType, slots=True):
 				line = Line(lineNumber, LineKind.Empty, rawMessageLine)
 			elif rawMessageLine.startswith("Command: "):
 				line = VivadoTclCommand.Parse(lineNumber, rawMessageLine)
+				errorMessage = "Line starting with 'Command:' was not a VivadoTclCommand."
 			else:
 				line = Line(lineNumber, LineKind.Unprocessed, rawMessageLine)
-				errorMessage = "Line starting with 'Command:' was not a VivadoTclCommand."
 
 			if line is None:
 				line = Line(lineNumber, LineKind.ProcessorError, rawMessageLine)

--- a/pyEDAA/OutputFilter/__init__.py
+++ b/pyEDAA/OutputFilter/__init__.py
@@ -34,7 +34,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2014-2025, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.2.0"
+__version__ =   "0.3.0"
 __keywords__ =  ["cli", "abstraction layer", "eda", "filter", "classification"]
 
 

--- a/run.ps1
+++ b/run.ps1
@@ -33,7 +33,7 @@ Param(
 )
 
 $PackageName = "pyEDAA.OutputFilter"
-$PackageVersion = "0.2.0"
+$PackageVersion = "0.3.0"
 
 # set default values
 $EnableDebug =        [bool]$PSCmdlet.MyInvocation.BoundParameters["Debug"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov ~= 6.2
 # Static Type Checking
 mypy ~= 1.16
 typing_extensions ~= 4.14
-lxml ~= 6.0
+lxml ~= 5.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov ~= 6.2
 # Static Type Checking
 mypy ~= 1.16
 typing_extensions ~= 4.14
-lxml ~= 5.4
+lxml ~= 6.0

--- a/tests/unit/Vivado/SynthesisLog.py
+++ b/tests/unit/Vivado/SynthesisLog.py
@@ -36,7 +36,8 @@ from pyTooling.Versioning                        import YearReleaseVersion
 
 from pyEDAA.OutputFilter.Xilinx                  import Document
 from pyEDAA.OutputFilter.Xilinx.Commands         import SynthesizeDesign
-from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import WritingSynthesisReport
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import WritingSynthesisReport, CrossBoundaryAndAreaOptimization, \
+	RTLElaboration
 
 if __name__ == "__main__": # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
@@ -60,6 +61,22 @@ class Stopwatch(TestCase):
 		self.assertEqual(YearReleaseVersion(2025, 1), processor._preamble.ToolVersion)
 
 		synthesis = processor[SynthesizeDesign]
+		self.assertEqual(69 - (5 + 5 + 2 + 10), len(synthesis.InfoMessages))
+		self.assertEqual(3, len(synthesis.WarningMessages))
+		self.assertEqual(0, len(synthesis.CriticalWarningMessages))
+		self.assertEqual(0, len(synthesis.ErrorMessages))
+
+		rtlElaboration = synthesis[RTLElaboration]
+		self.assertEqual(47, len(rtlElaboration.InfoMessages))
+		self.assertEqual(0, len(rtlElaboration.WarningMessages))
+		self.assertEqual(0, len(rtlElaboration.CriticalWarningMessages))
+		self.assertEqual(0, len(rtlElaboration.ErrorMessages))
+
+		crossBoundaryAndAreaOptimization = synthesis[CrossBoundaryAndAreaOptimization]
+		self.assertEqual(0, len(crossBoundaryAndAreaOptimization.InfoMessages))
+		self.assertEqual(3, len(crossBoundaryAndAreaOptimization.WarningMessages))
+		self.assertEqual(0, len(crossBoundaryAndAreaOptimization.CriticalWarningMessages))
+		self.assertEqual(0, len(crossBoundaryAndAreaOptimization.ErrorMessages))
 
 		self.assertEqual(0, len(synthesis[WritingSynthesisReport].Blackboxes))
 

--- a/tests/unit/Vivado/SynthesisLog.py
+++ b/tests/unit/Vivado/SynthesisLog.py
@@ -32,10 +32,11 @@
 from pathlib  import Path
 from unittest import TestCase as TestCase
 
-from pyTooling.Versioning       import YearReleaseVersion
+from pyTooling.Versioning                        import YearReleaseVersion
 
-from pyEDAA.OutputFilter.Xilinx                import Preamble
-from pyEDAA.OutputFilter.Xilinx.Synthesis      import Processor as SynthProc, WritingSynthesisReport
+from pyEDAA.OutputFilter.Xilinx                  import Document
+from pyEDAA.OutputFilter.Xilinx.Commands         import SynthesizeDesign
+from pyEDAA.OutputFilter.Xilinx.SynthesizeDesign import WritingSynthesisReport
 
 if __name__ == "__main__": # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
@@ -46,7 +47,7 @@ if __name__ == "__main__": # pragma: no cover
 class Stopwatch(TestCase):
 	def test_SynthesisLogfile(self) -> None:
 		logfile = Path("tests/data/Stopwatch/toplevel.vds")
-		processor = SynthProc(logfile)
+		processor = Document(logfile)
 		processor.Parse()
 
 		self.assertLess(processor.Duration, 0.1)
@@ -56,7 +57,15 @@ class Stopwatch(TestCase):
 		self.assertEqual(0, len(processor.CriticalWarningMessages))
 		self.assertEqual(0, len(processor.ErrorMessages))
 
-		self.assertEqual(YearReleaseVersion(2025, 1), processor[Preamble].ToolVersion)
+		self.assertEqual(YearReleaseVersion(2025, 1), processor._preamble.ToolVersion)
 
+		synthesis = processor[SynthesizeDesign]
 
-		self.assertEqual(0, len(processor[WritingSynthesisReport].Blackboxes))
+		self.assertEqual(0, len(synthesis[WritingSynthesisReport].Blackboxes))
+
+	def test_ImplementationLogfile(self) -> None:
+		logfile = Path("tests/data/Stopwatch/toplevel.vdi")
+		processor = Document(logfile)
+		processor.Parse()
+
+		self.assertLess(processor.Duration, 0.1)


### PR DESCRIPTION
# New Features

* Vivado logs:
  * Discover Vivado TCL commands like `synth_design`.
  * `synth_design`:
    * Handle sections and subsections.
    * Handle `ROM, RAM, DSP, Shift Register and Retiming Reporting` section.  
      See #18 
    * Handle intermediate `Finished ... Phase ...` outputs.
  * Vivado message collection per
    * Processor
    * per TCL command
    * per section
    * per subsection
  * New policy:
    * `IsIncompleteLog`
  * Line objects are now a double-linked list. Each line has a `Previous` and `Next` line object.
 
# Changes

* Vivado logs:
  * `Preamble` is now a member on `Processor`.
  * Synthesis related properties have been moved from `Processor` to `SynthesizeDesign`.
* CLI tool `pyedaa-outputfilter`:
  * Changed command `vivado-synth` to `vivado`.

# Bug Fixes

* Handle `----...----` line before a section start.

# Unit Tests

* Enhanced unit tests for `synth_design`.

----------
# Related Issues and Pull-Requests

* Fixes #18
